### PR TITLE
c-riscv-blink/Makefile: Check for riscv32-unknown-elf-gcc in different paths.

### DIFF
--- a/c-riscv-blink/Makefile
+++ b/c-riscv-blink/Makefile
@@ -4,6 +4,9 @@ GIT_VERSION := $(shell git describe --always --tags)
 ifneq (,$(wildcard /usr/bin/riscv32-unknown-elf-gcc 2>/dev/null))
 CROSS_COMPILE       ?= riscv32-unknown-elf-
 endif
+ifneq (,$(shell which riscv32-unknown-elf-gcc 2>/dev/null))
+CROSS_COMPILE       ?= riscv32-unknown-elf-
+endif
 ifneq (,$(shell which riscv64-unknown-elf-gcc 2>/dev/null))
 CROSS_COMPILE       ?= riscv64-unknown-elf-
 endif


### PR DESCRIPTION
riscv64-unknown-elf-gcc is already checked for in PATH, but riscv32-unknown-elf-gcc only in a specific directory.

Since the resulting information of this check is the same for specific or generic paths of that gcc, this will just do both.